### PR TITLE
Added togglability to Epop-message for compatibility with other addons

### DIFF
--- a/lua/terrortown/autorun/shared/sh_ceasefire.lua
+++ b/lua/terrortown/autorun/shared/sh_ceasefire.lua
@@ -8,6 +8,7 @@ end
 
 local ceasefire = GetConVar("ttt_ceasefire")
 local ceasefireDuration = GetConVar("ttt_ceasefire_duration")
+local showEpopMsg = GetConVar("ttt_ceasefire_showEpopMessage")
 
 local allowFallDamage = GetConVar("ttt_ceasefire_allowFallDamage")
 local allowDrowning = GetConVar("ttt_ceasefire_allowDrowning")
@@ -26,6 +27,8 @@ hook.Add("TTTBeginRound", "ceasefire_tttbeginround", function()
 	if not CLIENT then return end
 
 	STATUS:AddTimedStatus("ceasefire_status", ceasefireDuration:GetInt(), true)
+
+  if not showEpopMsg:GetBool() then return end
 
 	EPOP:AddMessage({
 		text = "Ceasefire is on for " .. ceasefireDuration:GetInt() .. " seconds.",
@@ -56,7 +59,11 @@ hook.Add("TTTEndRound", "ceasefire_tttendround", function()
 	if not ceasefire:GetBool() then return end
 
 	ceasefireTimer = CurTime() - 0.1
-	timer.Remove("ceasefire_timer_over")
+
+  -- Works, even if showEpopMsg is changed between timer-start and timer-finish
+  if timer.Exists("ceasefire_timer_over") then
+    timer.Remove("ceasefire_timer_over")
+  end
 end)
 
 hook.Add("PlayerTakeDamage", "ceasefire_playertakedamage" , function(ply, inflictor, att, dmg, dmginfo)

--- a/lua/terrortown/autorun/shared/sh_ceasefire.lua
+++ b/lua/terrortown/autorun/shared/sh_ceasefire.lua
@@ -60,7 +60,7 @@ hook.Add("TTTEndRound", "ceasefire_tttendround", function()
 
 	ceasefireTimer = CurTime() - 0.1
 
-  -- Works, even if showEpopMsg is changed between timer-start and timer-finish
+  -- Works, even if showEpopMsg-ConVar is changed between timer-start and timer-finish
   if timer.Exists("ceasefire_timer_over") then
     timer.Remove("ceasefire_timer_over")
   end

--- a/lua/terrortown/scripts/sh_ceasefire_cvars.lua
+++ b/lua/terrortown/scripts/sh_ceasefire_cvars.lua
@@ -19,7 +19,7 @@ if file.Exists("terrortown/scripts/sh_convarutil_local.lua", "LUA") then
 	--Convar(cg, false, "ttt_asm_shift_speed_modifier", 2, {FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED}, "Movement speed multiplier during the aiming sequence", "float", 0.01, 8, 2)
 
 	Convar(cg, false, "ttt_ceasefire", 1, {FCVAR_SERVER_CAN_EXECUTE, FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED}, "Should there be a Ceasefire at Roundbegin?", "bool", 0, 1, 0)
-  Convar(cg, false, "ttt_ceasefire_epopMessage", 1, {FCVAR_SERVER_CAN_EXECUTE, FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED}, "Should there be a notification at the top of the screen?", "bool", 0, 1, 0)
+  Convar(cg, false, "ttt_ceasefire_showEpopMessage", 1, {FCVAR_SERVER_CAN_EXECUTE, FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED}, "Should there be a notification at the top of the screen?", "bool", 0, 1, 0)
 	Convar(cg, false, "ttt_ceasefire_duration", 15, {FCVAR_SERVER_CAN_EXECUTE, FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED}, "How long the duration of the Ceasefire at Roundbegin should be?", "int", 3, 30, 0)
 	Convar(cg, false, "ttt_ceasefire_allowFallDamage", 1, {FCVAR_SERVER_CAN_EXECUTE, FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED}, "Should Fall Damage be allowed during Ceasefire?", "bool", 0, 1, 0)
 	Convar(cg, false, "ttt_ceasefire_allowDrowning", 1, {FCVAR_SERVER_CAN_EXECUTE, FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED}, "Should Drowning be allowed during Ceasefire?", "bool", 0, 1, 0)

--- a/lua/terrortown/scripts/sh_ceasefire_cvars.lua
+++ b/lua/terrortown/scripts/sh_ceasefire_cvars.lua
@@ -19,6 +19,7 @@ if file.Exists("terrortown/scripts/sh_convarutil_local.lua", "LUA") then
 	--Convar(cg, false, "ttt_asm_shift_speed_modifier", 2, {FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED}, "Movement speed multiplier during the aiming sequence", "float", 0.01, 8, 2)
 
 	Convar(cg, false, "ttt_ceasefire", 1, {FCVAR_SERVER_CAN_EXECUTE, FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED}, "Should there be a Ceasefire at Roundbegin?", "bool", 0, 1, 0)
+  Convar(cg, false, "ttt_ceasefire_epopMessage", 1, {FCVAR_SERVER_CAN_EXECUTE, FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED}, "Should there be a notification at the top of the screen?", "bool", 0, 1, 0)
 	Convar(cg, false, "ttt_ceasefire_duration", 15, {FCVAR_SERVER_CAN_EXECUTE, FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED}, "How long the duration of the Ceasefire at Roundbegin should be?", "int", 3, 30, 0)
 	Convar(cg, false, "ttt_ceasefire_allowFallDamage", 1, {FCVAR_SERVER_CAN_EXECUTE, FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED}, "Should Fall Damage be allowed during Ceasefire?", "bool", 0, 1, 0)
 	Convar(cg, false, "ttt_ceasefire_allowDrowning", 1, {FCVAR_SERVER_CAN_EXECUTE, FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED}, "Should Drowning be allowed during Ceasefire?", "bool", 0, 1, 0)


### PR DESCRIPTION
tl;dr: added new convar to toggle epop message, because other addons might have more important information delayed or dismissed because of the ceasefire message.

I added another convar in the same fashion as your own convars to be able to toggle the Epop-message at the top of the screen when the round starts. The changes are simple enough and don't really need explanation, I believe. If I am mistaken, feel free to ask. (Btw, thank you for knowing how that convar stuff works because I don't understand poo in that convar_util file of yours and I am glad I don't have to.)
Main reason for adding it is compatibility with other TTT(2) addons like the [Minigames-addon](https://steamcommunity.com/sharedfiles/filedetails/?id=2266863830) or roles like the [thief](https://steamcommunity.com/sharedfiles/filedetails/?id=2652144870).
If a server uses other addons which also utilise Epop, the information provided by those other addons often gets delayed or sometimes even completely dismissed if addons like this one use it first. Furthermore, if a static playerbase gets used to the ceasefire, the sidebar display is good enough and should have a way to open the epop-channel for compatibility.